### PR TITLE
Upgraded device info plus

### DIFF
--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.17.0
-  device_info_plus: ^4.0.0
+  device_info_plus: ^9.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Needed to support Vital.

Only reference  of device_info_plus is here: https://github.com/stellarsleep/flutter-plugins/blob/master/packages/health/lib/health.dart